### PR TITLE
Change info-sheet to allow for long names

### DIFF
--- a/info-sheet.tex
+++ b/info-sheet.tex
@@ -13,14 +13,22 @@
 
 \begin{minipage}[t]{0.4\columnwidth}
     \begin{flushleft}
-        Bearbeitung:\\
+        Bearbeitung:
+    \end{flushleft}
+\end{minipage}
+\begin{minipage}[t]{0.4\columnwidth}
+    \begin{flushleft}
+        \authorname
+    \end{flushleft}
+\end{minipage}\par
+\begin{minipage}[t]{0.4\columnwidth}
+    \begin{flushleft}
         Matrikelnummer:\\
         Abgabetermin:\\
     \end{flushleft}
 \end{minipage}
 \begin{minipage}[t]{0.4\columnwidth}
     \begin{flushleft}
-        \authorname\\
         \matnumber\\
         \hdate
     \end{flushleft}
@@ -29,16 +37,32 @@
 \begin{minipage}[t]{0.4\columnwidth}
     \begin{flushleft}
         Aufgabenstellung:\\
-        Zweitpr\"ufer:\\
-        Betreuung:\\
     \end{flushleft}
 \end{minipage}
 \begin{minipage}[t]{0.4\columnwidth}
     \begin{flushleft}
         \fxname\\
-        \sxname\\
-        \supname
     \end{flushleft}
+\end{minipage}\par
+\begin{minipage}[t]{0.4\columnwidth}
+  \begin{flushleft}
+    Zweitpr\"ufer:
+  \end{flushleft}
+\end{minipage}
+\begin{minipage}[t]{0.4\columnwidth}
+  \begin{flushleft}
+    \sxname
+  \end{flushleft}
+\end{minipage}\par
+\begin{minipage}[t]{0.4\columnwidth}
+  \begin{flushleft}
+    Betreuung:
+  \end{flushleft}
+\end{minipage}
+\begin{minipage}[t]{0.4\columnwidth}
+  \begin{flushleft}
+    \supname
+  \end{flushleft}
 \end{minipage}\par
 
 \vfill


### PR DESCRIPTION
If a name was longer than would fit on a single line, the formatting would look like this:

    Person 1:     Person 1 with a very very very
    Person 2:     very very long name
                  Person 2 with a short name

because all the names were in the same minipage. Now, every name is in a separate minipage, so we get the expected result:

    Person 1:     Person 1 with a very very very
                  very very long name
    Person 2:     Person 2 with a short name